### PR TITLE
Add OwnedLock to UnavailableError

### DIFF
--- a/lock/interface.go
+++ b/lock/interface.go
@@ -81,7 +81,8 @@ func NewLocker(ddbAPI dynamodbiface.DynamoDBAPI, tableName string, logger logger
 
 // UnavailableError represents an attempt to get or update a lock has a different owner
 type UnavailableError struct {
-	Err error
+	Err       error
+	OwnedLock Lock
 }
 
 func (l UnavailableError) Error() string {


### PR DESCRIPTION
## Overview
When a lock is unavailable add the current lock data so the owner can be figured out.

The drawback here is the extra dynamo call.  It doesn't appear `PutItem` will allow us to pull the "current" state out of the database, so we need the secondary call to populate the error.

## Testing
Adapted existing reacquire test - happy to add a new/different test if desired!