### PR TITLE
Add GetCurrentLock

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,6 +1,7 @@
-v0.2.0
+v0.3.0
 
-Add createdAt to locks
+Add GetCurrentLock
 
 Previously:
+- Add createdAt to locks
 - Initial release!

--- a/lock/interface.go
+++ b/lock/interface.go
@@ -59,6 +59,11 @@ type Locker interface {
 	// If the lock is held by someone else, that's generally not retryable, and that is represented by the error type UnavailableError. In this case, the caller can be certain that the caller does not still hold the lock.
 	// Any other error type could indicate that caller still holds the lock e.g. if there were a dynamo system error.
 	ReleaseLock(ctx context.Context, lock Lock) error
+
+	// GetCurrentLock will return the current lock for a key.  This is meant to help troubleshoot lock starvation.
+	// If there is no lock, nil will be returned for both lock and error
+	// This should not be used to "pre-check" for a lock as AcquireLock may still fail.
+	GetCurrentLock(ctx context.Context, key string) (*Lock, error)
 }
 
 // Lock is a representation of a row in the lock table.


### PR DESCRIPTION
## Overview
GetCurrentLock will return the current lock for a key.  This is meant to
help troubleshoot lock starvation.  If there is no lock, nil will be
returned for both lock and error. This should not be used to "pre-check"
for a lock as AcquireLock may still fail.

## Testing
2 new integration tests