### PR TITLE
Background heartbeat loop

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,7 +1,8 @@
-v0.3.0
+v0.3.1
 
-Add GetCurrentLock
+Bugfix: actually loop in the StartBackgroundHeartbeats loop.
 
 Previously:
+- Add GetCurrentLock
 - Add createdAt to locks
 - Initial release!


### PR DESCRIPTION
## Overview
Local testing confirmed what you'd expect from the code: the background heartbeat "loop" was, in fact, just heartbeating once, then doing nothing until `ctx.Done()` sent a message.

## Testing

<details>
<summary>Test Script</summary>

```golang
package main

import (
	"context"
	"fmt"
	"log"
	"time"

	"github.com/Clever/dynamodb-lock-go/lock"
	"github.com/aws/aws-sdk-go/aws"
	"github.com/aws/aws-sdk-go/aws/session"
	"github.com/aws/aws-sdk-go/service/dynamodb"
	"gopkg.in/Clever/kayvee-go.v6/logger"
)

func main() {
	logger := logger.New("logger")
	ddb := dynamodb.New(session.Must(session.NewSession(&aws.Config{
		Region: aws.String("us-west-2"),
	})))
	locker := lock.NewLocker(ddb, "clever-dev--integration-testing-service-db-EnvironmentLocks", logger)

	ctx := context.Background()
	duration := 5 * time.Minute
	myLock, err := locker.AcquireLock(ctx, lock.AcquireLockInput{
		Key:           "test",
		Owner:         "test",
		LeaseDuration: &duration,
	})
	if err != nil {
		log.Fatalf("Acquiring lock: %v", err)
	}
	fmt.Printf("Lock: %+v\n", myLock)

	ch := locker.StartBackgroundHeartbeats(ctx, myLock, 10*time.Second, 5*time.Minute)
	ticker := time.NewTicker(10 * time.Second)
	defer ticker.Stop()
	for {
		select {
		case value := <-ch:
			log.Printf("got error from heartbeats: %v\n", value)
		case <-ticker.C:
			log.Printf("+%v\n", myLock)
		}

	}
}
```
</details>

On `v0.3.0` of dynamodb-lock-go, it only logs the DynamoDB debug log that is emitted on every operation once. On this branch, it happens every 10 seconds, as you would expect.