### PR TITLE
Force utc

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,8 +1,9 @@
-v0.3.1
+v0.3.2
 
-Bugfix: actually loop in the StartBackgroundHeartbeats loop.
+Bugfix: use UTC for all times in DynamoDB, regardless of client's local time.
 
 Previously:
+- Bugfix: actually loop in the StartBackgroundHeartbeats loop.
 - Add GetCurrentLock
 - Add createdAt to locks
 - Initial release!


### PR DESCRIPTION
## Overview
We have seen an error where a lock acquired while local time was
UTC-8 was able to be acquired by a different user in UTC
immediately (before lease expires) because of doing a string
comparison between the RFC3339 for the UTC-8 time and the UTC
time E.g. one client would write the lease time as
2021-11-18T10:00.0000-08:00 (UTC-8) then another client would do
a string comparison to 2021-11-18T15:00:00.000Z (UTC) The second
time is in the before the first time, so the lock is still
leased, but the naive string comparison sees that the first
string is less.

## Testing

The test added in the first commit fails locally, but the after the second commit it succeeds).