### PR TITLE
[INFRANG-6876] Upgrade to go 1.24

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ executors:
   common-executor:
     working_directory: ~/go/src/github.com/Clever/dynamodb-lock-go
     docker:
-    - image: cimg/go:1.21
+    - image: cimg/go:1.24
       environment:
         AWS_ACCESS_KEY_ID: 'DUMMYIDEXAMPLE'
         AWS_SECRET_ACCESS_KEY: 'DUMMYEXAMPLEKEY'

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Clever/dynamodb-lock-go
 
-go 1.21
+go 1.24
 
 require (
 	github.com/Clever/kayvee-go/v7 v7.7.0

--- a/go.sum
+++ b/go.sum
@@ -187,7 +187,6 @@ github.com/googleapis/gax-go/v2 v2.2.0/go.mod h1:as02EH8zWkzwUoLbBaFeQ+arQaj/Oth
 github.com/googleapis/gax-go/v2 v2.3.0/go.mod h1:b8LNqSzNabLiUpXKkY7HAR5jr6bIT99EXz9pXxye9YM=
 github.com/googleapis/gax-go/v2 v2.4.0/go.mod h1:XOTVJ59hdnfJLIP/dh8n5CGryZR2LxK9wbMD5+iXC6c=
 github.com/googleapis/go-type-adapters v1.0.0/go.mod h1:zHW75FOG2aur7gAO2B+MLby+cLsWGBF62rFAi7WjWO4=
-github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4M0+kPpLofRdBo=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0/go.mod h1:hgWBS7lorOAVIJEQMi4ZsPv9hVvWI6+ch50m39Pf2Ks=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.11.3 h1:lLT7ZLSzGLI08vc9cpd+tYmNWjdKDqyr/2L+f6U12Fk=

--- a/golang.mk
+++ b/golang.mk
@@ -1,7 +1,7 @@
 # This is the default Clever Golang Makefile.
 # It is stored in the dev-handbook repo, github.com/Clever/dev-handbook
 # Please do not alter this file directly.
-GOLANG_MK_VERSION := 1.2.1
+GOLANG_MK_VERSION := 1.3.1
 
 SHELL := /bin/bash
 SYSTEM := $(shell uname -a | cut -d" " -f1 | tr '[:upper:]' '[:lower:]')
@@ -48,7 +48,7 @@ golang-ensure-curl-installed:
 # We pin its version because an update could add a new lint check which would make
 # previously passing tests start failing without changing our code.
 # this package is deprecated and frozen
-# Infra recomendation is to eventaully move to https://github.com/golangci/golangci-lint so don't fail on linting error for now
+# Infra recommendation is to eventually move to https://github.com/golangci/golangci-lint so don't fail on linting error for now
 GOLINT := $(GOPATH)/bin/golint
 $(GOLINT):
 	go install -mod=readonly golang.org/x/lint/golint@738671d3881b9731cc63024d5d88cf28db875626
@@ -159,17 +159,28 @@ $(call golang-vet,$(1))
 $(call golang-test-strict-cover,$(1))
 endef
 
-# golang-build: builds a golang binary. ensures CGO build is done during CI. This is needed to make a binary that works with a Docker alpine image.
+# golang-build: builds a golang binary
 # arg1: pkg path
 # arg2: executable name
 define golang-build
 @echo "BUILDING $(2)..."
-@if [ -z "$$CI" ]; then \
-	go build -o bin/$(2) $(1); \
-else \
-	echo "-> Building CGO binary"; \
-	CGO_ENABLED=0 go build -installsuffix cgo -o bin/$(2) $(1); \
-fi;
+@CGO_ENABLED=0 go build -o bin/$(2) $(1);
+endef
+
+# golang-debug-build: builds a golang binary with debugging capabilities
+# arg1: pkg path
+# arg2: executable name
+define golang-debug-build
+@echo "BUILDING $(2) FOR DEBUG..."
+@CGO_ENABLED=0 go build -gcflags="all=-N -l" -o bin/$(2) $(1);
+endef
+
+# golang-cgo-build: builds a golang binary with CGO
+# arg1: pkg path
+# arg2: executable name
+define golang-cgo-build
+@echo "BUILDING $(2) WITH CGO ..."
+@CGO_ENABLED=1 go build -installsuffix cgo -o bin/$(2) $(1);
 endef
 
 # golang-setup-coverage: set up the coverage file


### PR DESCRIPTION
<!-- This template should be used as a living PR template for future go migrations -->

# JIRA
https://clever.atlassian.net/browse/INFRANG-6876

# About
This PR upgrades this repo to Go version 1.24. See the [release notes](https://tip.golang.org/doc/go1.24) for full details.

It performs the following changes:
1. Upgrade the module to 1.24.
2. Upgrade the golang.mk file to the latest version.
3. Replaces any `tools.go` file with the new go.mod tools directive.
4. Updates any circle CI build images to 1.24.
5. Updates the go version check in the makefile.
6. Updates any debian docker images to a version with a glibc compatible with the CI build image.



#### New Go Vet Check
Go vet in 1.24 introduces a new check which catches non-constant format strings in calls to printf functions. This has a tendency to find bugs in existing code, however the fix is pretty strait forward should your CI begin to fail. You can see more details in the official issue https://github.com/golang/go/issues/60529. If your CI fails because of this, you may add an extra commit resolving the issue, then merge. The microplane script attempts to resolve as many of these cases as possible automatically.

# Testing
Go version upgrades have historically been extremely stable. The only exception has been incompatible glibc versions which have been tested for in workers before merging. All standard CI testing is also performed before merging.

# Problems Upgrading?
Checkout this [google doc](https://docs.google.com/document/d/1ctg3eT8zkKHXqsf7CCUBB77ERmEVMsyZoYAIxXm19hs/edit?usp=sharing) for knowledge sharing any problems you encounter during upgrades!
